### PR TITLE
Bring back allowed ECR repository name

### DIFF
--- a/bin/build_docker_images.sh
+++ b/bin/build_docker_images.sh
@@ -8,7 +8,7 @@ if [ "x$REPO_URL" = "x" ]; then
   exit 1
 fi
 
-IMAGE_NAME="dashevo/drive"
+IMAGE_NAME="dashevo/dashdrive"
 DRIVE_VERSION=$(node -p "require('./package.json').version")
 
 docker build --build-arg NODE_ENV=development \


### PR DESCRIPTION
ECR still waiting for the old repo name `dashevo/dashdrive` https://travis-ci.com/dashevo/drive/builds/106347905#L1570