### PR TITLE
fix: invalid Tendermint RPC port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,10 +23,8 @@ DASHCORE_JSON_RPC_PORT=9998
 DASHCORE_JSON_RPC_USER=dashrpc
 DASHCORE_JSON_RPC_PASS=password
 
-# Tendermint host and port settings
-# to retrieve identities from
-TENDERMINT_HOST=127.0.0.1
-TENDERMINT_PORT=26658
+# Tendermint RPC host and port
+TENDERMINT_RPC_HOST=127.0.0.1
 TENDERMINT_RPC_PORT=26657
 
 # SERVICE_IMAGE_DRIVE=   # Drive image name, if omitted dashpay/dashrive is used

--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,7 @@ DASHCORE_JSON_RPC_PASS=password
 # to retrieve identities from
 TENDERMINT_HOST=127.0.0.1
 TENDERMINT_PORT=26658
+TENDERMINT_RPC_PORT=26657
 
 # SERVICE_IMAGE_DRIVE=   # Drive image name, if omitted dashpay/dashrive is used
 # SERVICE_IMAGE_DAPI=    # DAPI image name, if omitted dashpay/dapi is used

--- a/lib/app/UpdateStateApp.js
+++ b/lib/app/UpdateStateApp.js
@@ -90,7 +90,7 @@ class UpdateStateApp {
 
     this.tendermintRPCClient = new JaysonClient({
       host: this.options.getTendermintHost(),
-      port: this.options.getTendermintPort(),
+      port: this.options.getTendermintRpcPort(),
     });
 
     this.mongoClient = await MongoClient.connect(

--- a/lib/app/UpdateStateApp.js
+++ b/lib/app/UpdateStateApp.js
@@ -89,7 +89,7 @@ class UpdateStateApp {
     });
 
     this.tendermintRPCClient = new JaysonClient({
-      host: this.options.getTendermintHost(),
+      host: this.options.getTendermintRpcHost(),
       port: this.options.getTendermintRpcPort(),
     });
 

--- a/lib/app/UpdateStateAppOptions.js
+++ b/lib/app/UpdateStateAppOptions.js
@@ -8,8 +8,7 @@ class UpdateStateAppOptions {
     this.dashCoreJsonRpcPort = options.DASHCORE_JSON_RPC_PORT;
     this.dashCoreJsonRpcUser = options.DASHCORE_JSON_RPC_USER;
     this.dashCoreJsonRpcPass = options.DASHCORE_JSON_RPC_PASS;
-    this.tendermintHost = options.TENDERMINT_HOST;
-    this.tendermintPort = options.TENDERMINT_PORT;
+    this.tendermintRpcHost = options.TENDERMINT_RPC_HOST;
     this.tendermintRpcPort = options.TENDERMINT_RPC_PORT;
   }
 
@@ -45,12 +44,8 @@ class UpdateStateAppOptions {
     return this.dashCoreJsonRpcPass;
   }
 
-  getTendermintHost() {
-    return this.tendermintHost;
-  }
-
-  getTendermintPort() {
-    return this.tendermintPort;
+  getTendermintRpcHost() {
+    return this.tendermintRpcHost;
   }
 
   getTendermintRpcPort() {

--- a/lib/app/UpdateStateAppOptions.js
+++ b/lib/app/UpdateStateAppOptions.js
@@ -10,6 +10,7 @@ class UpdateStateAppOptions {
     this.dashCoreJsonRpcPass = options.DASHCORE_JSON_RPC_PASS;
     this.tendermintHost = options.TENDERMINT_HOST;
     this.tendermintPort = options.TENDERMINT_PORT;
+    this.tendermintRpcPort = options.TENDERMINT_RPC_PORT;
   }
 
   getStateViewMongoDBUrl() {
@@ -50,6 +51,10 @@ class UpdateStateAppOptions {
 
   getTendermintPort() {
     return this.tendermintPort;
+  }
+
+  getTendermintRpcPort() {
+    return this.tendermintRpcPort;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -284,11 +284,11 @@
       }
     },
     "@dashevo/dpp": {
-      "version": "0.10.0-dev.1",
-      "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.10.0-dev.1.tgz",
-      "integrity": "sha512-nLTFgWdgN3losn7IEfK5R86PPAt42rp1zU7RM4ne/P6OmdEH3utjLrz5ZuiXKJ8IxOKN/Vb8A90tx6tTDdukog==",
+      "version": "0.10.0-dev.3",
+      "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.10.0-dev.3.tgz",
+      "integrity": "sha512-DED93gUP/UguWvW/GCFpPDPDmnkA64THAi+kBMKSZYZI7fazj+nkP6x6wZnfcUy3jmnqVHyZLwHRRLAYDlAfhQ==",
       "requires": {
-        "@dashevo/dashcore-lib": "^0.17.11",
+        "@dashevo/dashcore-lib": "0.18.0",
         "ajv": "^6.5.4",
         "bs58": "^4.0.1",
         "cbor": "^4.1.1",
@@ -296,23 +296,6 @@
         "lodash.mergewith": "^4.6.2",
         "lodash.set": "^4.3.2",
         "multihashes": "^0.4.13"
-      },
-      "dependencies": {
-        "@dashevo/dashcore-lib": {
-          "version": "0.17.12",
-          "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.17.12.tgz",
-          "integrity": "sha512-ZZFlWqzGTklW9uSsj4QNe1k3e5vrqDTfeaZwt2oU0dbmMltkFgNifx7Rq6ij5erRDKFoIkOG1ZM6Q4brc9eWUw==",
-          "requires": {
-            "@dashevo/x11-hash-js": "^1.0.2",
-            "bloom-filter": "^0.2.0",
-            "bn.js": "=4.11.8",
-            "bs58": "=4.0.1",
-            "elliptic": "=6.4.1",
-            "inherits": "=2.0.1",
-            "lodash": "^4.17.15",
-            "unorm": "^1.4.1"
-          }
-        }
       }
     },
     "@dashevo/drive-grpc": {


### PR DESCRIPTION
There are several Tendermint ports for Tendermint core and one for the RPC. The one used here by the tendermintRPCClient by default is 26657.