### PR TITLE
docs: remove reference to IPFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Decentralized application storage on the Dash network
 
-Drive is the storage component of Dash Platform, allowing developers to store and secure their application data through Dash's masternode network. Application data structures are defined by a data contract, which is stored on Drive and used to verify/validate updates to your application data. An application's current state is stored in the State View, which is a MongoDB instance hosted on a masternode. Historical application data is stored in IPFS and propagated to other nodes, thereby, ensuring data redundancy.
+Drive is the storage component of Dash Platform, allowing developers to store and secure their application data through Dash's masternode network. Application data structures are defined by a data contract, which is stored on Drive and used to verify/validate updates to your application data. An application's current state is stored in the State View, which is a MongoDB instance hosted on a masternode. Historical application data (State Transitions) are stored on the Platform Chain, a blockchain  which is propagated to all masternodes, ensuring data redundancy.
 
 ![Drive Architecure Diagram](architecture.png)
 


### PR DESCRIPTION
Docs Only: Temporarily remove an outdated/incorrect reference to IPFS as storage component.
I'm sure better updates will be made in the near future but opening this in the meantime!