### PR TITLE
fix: document repository not created properly due to missing `await`

### DIFF
--- a/lib/dpp/DriveStateRepository.js
+++ b/lib/dpp/DriveStateRepository.js
@@ -147,7 +147,7 @@ class DriveStateRepository {
   async removeDocument(contractId, type, id) {
     const transaction = this.getDBTransaction('document');
 
-    const repository = this.createDocumentRepository(
+    const repository = await this.createDocumentRepository(
       contractId,
       type,
     );

--- a/test/unit/dpp/DriveStateRepository.spec.js
+++ b/test/unit/dpp/DriveStateRepository.spec.js
@@ -174,7 +174,7 @@ describe('DriveStateRepository', () => {
   describe('#storeDocument', () => {
     it('should store document in repository', async function it() {
       const storeMock = this.sinon.stub();
-      createDocumentRepositoryMock.returns({
+      createDocumentRepositoryMock.resolves({
         store: storeMock,
       });
 
@@ -196,7 +196,7 @@ describe('DriveStateRepository', () => {
       const type = 'documentType';
 
       const deleteMock = this.sinon.stub();
-      createDocumentRepositoryMock.returns({
+      createDocumentRepositoryMock.resolves({
         delete: deleteMock,
       });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Document repository value was not properly created due to missing `await`

## What was done?
<!--- Describe your changes in detail -->
Added missing `await` in `DriveStateRepository`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run test`

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
