### PR TITLE
feat: increase MongoDB query allowed field length

### DIFF
--- a/lib/document/query/jsonSchema.js
+++ b/lib/document/query/jsonSchema.js
@@ -13,7 +13,7 @@ module.exports = {
       oneOf: [
         {
           type: 'string',
-          maxLength: 512,
+          maxLength: 1024,
         },
         {
           type: 'number',

--- a/test/unit/document/query/validateQueryFactory.spec.js
+++ b/test/unit/document/query/validateQueryFactory.spec.js
@@ -352,15 +352,15 @@ describe('validateQueryFactory', () => {
             expect(result.isValid()).to.be.true();
           });
 
-          it('should return invalid result if "<" operator used with a string value longer than 512 chars', () => {
-            const longString = 't'.repeat(512);
+          it('should return invalid result if "<" operator used with a string value longer than 1024 chars', () => {
+            const longString = 't'.repeat(1024);
 
             let result = validateQuery({ where: [['a', '<', longString]] }, documentSchema);
 
             expect(result).to.be.instanceOf(ValidationResult);
             expect(result.isValid()).to.be.true();
 
-            const veryLongString = 't'.repeat(513);
+            const veryLongString = 't'.repeat(1025);
 
             result = validateQuery({ where: [['a', '<', veryLongString]] }, documentSchema);
 
@@ -368,7 +368,7 @@ describe('validateQueryFactory', () => {
             expect(result.isValid()).to.be.false();
             expect(result.errors[0].dataPath).to.be.equal('.where[0][2]');
             expect(result.errors[0].keyword).to.be.equal('maxLength');
-            expect(result.errors[0].params.limit).to.be.equal(512);
+            expect(result.errors[0].params.limit).to.be.equal(1024);
           });
 
           it('should return valid result if "<" operator used with a boolean value', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Increased allowed `MongoDB` query item length to `1024`

## What was done?
<!--- Describe your changes in detail -->
Increased allowed `MongoDB` query item length to `1024`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
